### PR TITLE
Add getCurrentNtpTimeMs

### DIFF
--- a/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
@@ -36,6 +36,11 @@ interface KronosClock : Clock {
         return getCurrentTime().posixTimeMs
     }
 
+    /**
+     * @return the current time in milliseconds, or null if no ntp sync has occurred.
+     */
+    fun getCurrentNtpTimeMs(): Long?
+
     fun sync(): Boolean
     fun syncInBackground()
     fun shutdown()

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
@@ -19,4 +19,6 @@ internal class KronosClockImpl(private val ntpService: SntpService, private val 
         val currentTime = ntpService.currentTime()
         return currentTime ?: KronosTime(posixTimeMs = fallbackClock.getCurrentTimeMs(), timeSinceLastNtpSyncMs = null)
     }
+
+    override fun getCurrentNtpTimeMs() : Long? = ntpService.currentTime()?.posixTimeMs
 }


### PR DESCRIPTION
Add a method that will only ever return NTP synced time, or null. 

We currently have two options for getting time:
- `getCurrentTimeMs()` always returns a time as a `Long`. It falls back to the local clock if no ntp sync has occurred.
- `getCurrentTime()` always returns a time as a `KronosTime`. The `KronosTime.posixTimeMs` is equal to the value of `getCurrentTimeMs()`. You can discover whether we fell back to the fallback clock by checking `timeSinceLastNtpSyncMs == null`. This works, but seems unnecessarily complicated.