### PR TITLE
Add docs to Clock

### DIFF
--- a/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
@@ -2,7 +2,7 @@ package com.lyft.kronos
 
 interface Clock {
     /**
-     * @return the current time in milliseconds.
+     * @return the current time in milliseconds (the number of milliseconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970).
      */
     fun getCurrentTimeMs(): Long
 
@@ -24,14 +24,17 @@ data class KronosTime(
         val timeSinceLastNtpSyncMs: Long?
 )
 
-/**
- * When [KronosClock] has been synchronized, calling [getCurrentTimeMs]
- * will return the true time. However if [sync] fails or the class has
- * been shutdown via [shutdown] method, then it will return the time
- * indicated by the local device.
- */
 interface KronosClock : Clock {
-    fun getCurrentTime(): KronosTime
+
+    /**
+     * Return the number of milliseconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970.
+     *
+     * Note that calling this method will trigger [syncInBackground] being called when necessary.
+     * You still call [sync]/[syncInBackground] once to ensure you have the correct
+     * as soon as possible.
+     *
+     * @return the current time in milliseconds.
+     */
     override fun getCurrentTimeMs(): Long {
         return getCurrentTime().posixTimeMs
     }
@@ -41,7 +44,29 @@ interface KronosClock : Clock {
      */
     fun getCurrentNtpTimeMs(): Long?
 
+    /**
+     * Same as [getCurrentTimeMs], but returned [KronosTime] object includes time since last NTP sync, or null if the time is coming from the fallback clock.
+     *
+     * @return [KronosTime] for the current time
+     */
+    fun getCurrentTime(): KronosTime
+
+    /**
+     * Synchronize time an NTP server.
+     *
+     * @return true on the first successful response, false if no successful response.
+     */
     fun sync(): Boolean
+
+    /**
+     * Calls [sync] in a background thread. This method returns immediately.
+     */
     fun syncInBackground()
+
+    /**
+     * You can call [shutdown] when you no longer need this service. This will shutdown
+     * the thread that perform sync in the background. Any subsequent call to [currentTime]
+     * will throw [IllegalStateException].
+     */
     fun shutdown()
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
@@ -30,7 +30,7 @@ interface KronosClock : Clock {
      * Return the number of milliseconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970.
      *
      * Note that calling this method will trigger [syncInBackground] being called when necessary.
-     * You still call [sync]/[syncInBackground] once to ensure you have the correct
+     * You should still call [sync]/[syncInBackground] once to ensure you have the correct time
      * as soon as possible.
      *
      * @return the current time in milliseconds.
@@ -45,14 +45,12 @@ interface KronosClock : Clock {
     fun getCurrentNtpTimeMs(): Long?
 
     /**
-     * Same as [getCurrentTimeMs], but returned [KronosTime] object includes time since last NTP sync, or null if the time is coming from the fallback clock.
-     *
      * @return [KronosTime] for the current time
      */
     fun getCurrentTime(): KronosTime
 
     /**
-     * Synchronize time an NTP server.
+     * Synchronize time with an NTP server.
      *
      * @return true on the first successful response, false if no successful response.
      */
@@ -64,9 +62,8 @@ interface KronosClock : Clock {
     fun syncInBackground()
 
     /**
-     * You can call [shutdown] when you no longer need this service. This will shutdown
-     * the thread that perform sync in the background. Any subsequent call to [currentTime]
-     * will throw [IllegalStateException].
+     * Shuts down the thread that performs syncing in the background. Any subsequent call to [currentTime]
+     * will throw [IllegalStateException]. You can call [shutdown] when you no longer need this service.
      */
     fun shutdown()
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
@@ -46,7 +46,7 @@ internal interface SntpService {
 
     /**
      * You should call [shutdown] when you no longer need this service. This will shutdown
-     * the thread that perform sync in the background. Any subsequent call to [currentTimeMs]
+     * the thread that perform sync in the background. Any subsequent call to [currentTime]
      * will throw [IllegalStateException].
      */
     fun shutdown()

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
@@ -46,7 +46,7 @@ internal interface SntpService {
 
     /**
      * You should call [shutdown] when you no longer need this service. This will shutdown
-     * the thread that perform sync in the background. Any subsequent call to [currentTime]
+     * the thread that performs syncing in the background. Any subsequent call to [currentTime]
      * will throw [IllegalStateException].
      */
     fun shutdown()


### PR DESCRIPTION
We currently have docs on the internal class `SntpService` to which these methods pass through, but not on the external API itself. Add initial documentation to the `Clock` and `KronosClock` interfaces.