### PR TITLE
Throw custom exception when NTP sync response invalid

### DIFF
--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/NTPSyncException.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/NTPSyncException.kt
@@ -1,0 +1,5 @@
+package com.lyft.kronos.internal.ntp
+
+import java.lang.RuntimeException
+
+class NTPSyncException(message: String) : RuntimeException(message)

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
@@ -152,7 +152,7 @@ internal class SntpServiceImpl @JvmOverloads constructor(private val sntpClient:
             try {
                 val response = sntpClient.requestTime(host, requestTimeoutMs)
                 if (response.currentTimeMs < 0) {
-                    throw IllegalArgumentException("Invalid time ${response.currentTimeMs} received from $host")
+                    throw NTPSyncException("Invalid time ${response.currentTimeMs} received from $host")
                 }
                 responseCache.update(response)
                 val cachedOffset = response.offsetMs


### PR DESCRIPTION
Add custom exception for easier identification.