### PR TITLE
Fix typo in travis deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 deploy:
   skip_cleanup: true
   provider: script
-  script: PUBLISH_RELEASE=true ./ci.sh
+  script: PUBLISH_RELEASE=true ./ci
   on:
     repo: lyft/Kronos-Android
     tags: true


### PR DESCRIPTION
Fixes a typo preventing travis from deploying kronos to maven. (our ci script doesn't include `.sh`)