### PR TITLE
Propose removing integer requirement for versions

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -20,7 +20,7 @@ private def validateTagAndVersionForPublishing() {
     }
 
     for (int i = 0; i < semVerComponents.length - 1; i++) {
-        if (!semVerComponents[i].isInteger() || Integer.parseInt(semVerComponents[i] < 0)) {
+        if (!semVerComponents[i].isInteger() || Integer.parseInt(semVerComponents[i]) < 0) {
             throw new IllegalStateException(
                     "Publishing is not allowed because current projectVersion " + "is not semantic. First two components should be integers. projectVersion = $projectVersion")
         }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -18,13 +18,6 @@ private def validateTagAndVersionForPublishing() {
         throw new IllegalStateException(
             "Publishing is not allowed because current projectVersion " + "is not semantic, should have 3 components. projectVersion = $projectVersion")
     }
-
-    for (String semVerComponent : semVerComponents) {
-        if (!semVerComponent.isInteger() || Integer.parseInt(semVerComponent) < 0) {
-            throw new IllegalStateException(
-                "Publishing is not allowed because current projectVersion " + "is not semantic, components should be integers. projectVersion = $projectVersion")
-        }
-    }
 }
 
 task validatePublishing {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -18,6 +18,13 @@ private def validateTagAndVersionForPublishing() {
         throw new IllegalStateException(
             "Publishing is not allowed because current projectVersion " + "is not semantic, should have 3 components. projectVersion = $projectVersion")
     }
+
+    for (int i = 0; i < semVerComponents.length - 1; i++) {
+        if (!semVerComponents[i].isInteger() || Integer.parseInt(semVerComponents[i] < 0)) {
+            throw new IllegalStateException(
+                    "Publishing is not allowed because current projectVersion " + "is not semantic. First two components should be integers. projectVersion = $projectVersion")
+        }
+    }
 }
 
 task validatePublishing {


### PR DESCRIPTION
To release an alpha version, we need to include the word `alpha` in the version, which is not an integer.