### PR TITLE
Apply gradle-nexus-staging-plugin to close and release repo on sonatype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,11 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+
+        // Uploads artifacts to oss.sonatype.org
         classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.3.0"
+        // "Closes" and "Releases" repository on oss.sonatype.org to finish release process.
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -59,4 +63,11 @@ private def projectVersion() {
     }
 
     return tag
+}
+
+apply plugin: 'io.codearte.nexus-staging'
+
+nexusStaging {
+    username = System.getenv("MAVEN_CENTRAL_USERNAME")
+    password = System.getenv("MAVEN_CENTRAL_PASSWORD")
 }

--- a/ci
+++ b/ci
@@ -54,4 +54,7 @@ else
     unset GPG_OWNERTRUST
 
     ./gradlew --stacktrace --info build publishToSonatype -Psigning.keyId="$GPG_KEY_ID" -Psigning.password="$GPG_PASSPHRASE" -Psigning.secretKeyRingFile="$HOME/.gnupg/secring.gpg"
+
+    # Run closeAndReleaseRepository separately to avoid contention between publishing and closing.
+    ./gradlew --stacktrace --info closeAndReleaseRepository
 fi


### PR DESCRIPTION
I forgot to apply https://github.com/Codearte/gradle-nexus-staging-plugin because "staging" in its name always confused me, we don't have Sonatype staging setup in this repo. (Spotted by @ghackett)

Now we should be actually "closing" and "releasing" the upload on Sonatype, it's a shame you need 3 Gradle plugins to release a library, sigh.