### PR TITLE
Configure packageGroup for nexusStaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ private def projectVersion() {
 apply plugin: 'io.codearte.nexus-staging'
 
 nexusStaging {
+    packageGroup = "com.lyft"
     username = System.getenv("MAVEN_CENTRAL_USERNAME")
     password = System.getenv("MAVEN_CENTRAL_PASSWORD")
 }


### PR DESCRIPTION
In our case `packageGroup` (`com.lyft`) is different from `groupId` (`com.lyft.kronos`) thus plugin couldn't fetch `stagingProfileId`