### PR TITLE
Publish -sources and -javadoc jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
         // Uploads artifacts to oss.sonatype.org
         classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.3.0"
         // "Closes" and "Releases" repository on oss.sonatype.org to finish release process.

--- a/gradle/publish-android.gradle
+++ b/gradle/publish-android.gradle
@@ -1,4 +1,13 @@
 apply plugin: 'maven-publish'
+apply plugin: 'org.jetbrains.dokka-android'
+
+task sourcesJar(type: Jar) {
+    from project.android.sourceSets.main.java.srcDirs
+}
+
+task javadocJar(type: Jar, dependsOn: dokka) {
+    from dokka.outputDirectory
+}
 
 project.afterEvaluate {
     publishing {
@@ -8,6 +17,15 @@ project.afterEvaluate {
                 artifactId project.name
                 version project.version
                 artifact bundleReleaseAar
+
+                artifact sourcesJar {
+                    classifier "sources"
+                }
+
+                artifact javadocJar {
+                    classifier "javadoc"
+                }
+
                 pom.withXml {
                     final dependencies = asNode().appendNode('dependencies')
 

--- a/gradle/publish-java.gradle
+++ b/gradle/publish-java.gradle
@@ -1,5 +1,13 @@
 apply plugin: 'maven-publish'
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    from javadoc.destinationDir
+}
+
 publishing {
     publications {
         LibraryPublication(MavenPublication) {
@@ -7,6 +15,14 @@ publishing {
             artifactId project.name
             version project.version
             from components.java
+
+            artifact sourcesJar {
+                classifier "sources"
+            }
+
+            artifact javadocJar {
+                classifier "javadoc"
+            }
         }
     }
 }


### PR DESCRIPTION
Maven central requires these to be published, otherwise it fails validation.