### PR TITLE
Add pom metadata

### DIFF
--- a/gradle/pom.gradle
+++ b/gradle/pom.gradle
@@ -1,0 +1,26 @@
+ext.pomMetadata = {
+    pom {
+        name = "Kronos"
+        description = "An Open Source Kotlin SNTP library"
+        url = "https://github.com/lyft/Kronos-Android"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "repo"
+            }
+        }
+        developers {
+            developer {
+                id = "lyft"
+                name = "Lyft Inc."
+                email = "maven@lyft.com"
+            }
+        }
+        scm {
+            connection = "scm:git:git://github.com/lyft/Kronos-Android.git"
+            developerConnection = "scm:git:ssh://git@github.com/lyft/Kronos-Android.git"
+            url = "https://github.com/lyft/Kronos-Android.git"
+        }
+    }
+}

--- a/gradle/publish-android.gradle
+++ b/gradle/publish-android.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'org.jetbrains.dokka-android'
+apply from: "$rootProject.rootDir/gradle/pom.gradle"
 
 task sourcesJar(type: Jar) {
     from project.android.sourceSets.main.java.srcDirs
@@ -25,6 +26,8 @@ project.afterEvaluate {
                 artifact javadocJar {
                     classifier "javadoc"
                 }
+
+                with(pomMetadata)
 
                 pom.withXml {
                     final dependencies = asNode().appendNode('dependencies')

--- a/gradle/publish-java.gradle
+++ b/gradle/publish-java.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'maven-publish'
+apply from: "$rootProject.rootDir/gradle/pom.gradle"
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
@@ -23,6 +24,8 @@ publishing {
             artifact javadocJar {
                 classifier "javadoc"
             }
+
+            with(pomMetadata)
         }
     }
 }


### PR DESCRIPTION
Fixes issues flagged by Maven Central

```console
Invalid POM: /com/lyft/kronos/kronos-android/0.0.1-alpha01/kronos-android-0.0.1-alpha01.pom: 
Project name missing, 
Project description missing, 
Project URL missing, 
License information missing, 
SCM URL missing, 
Developer information missing
```