### PR TITLE
Cache api

### DIFF
--- a/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
@@ -41,9 +41,9 @@ interface KronosClock : Clock {
 
     /**
      * Unlike the [getCurrentTimeMs] method, synchronization is not started here.
-     * Outdated values are represented as null.
+     * Unknown or expired time represented as null.
      *
-     * @return the current time in milliseconds, or null if no ntp sync has occurred.
+     * @return the current time in milliseconds, or null.
      */
     fun getCachedNtpTimeMs(): Long?
 

--- a/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
@@ -40,9 +40,12 @@ interface KronosClock : Clock {
     }
 
     /**
+     * Unlike the [getCurrentTimeMs] method, synchronization is not started here.
+     * Outdated values are represented as null.
+     *
      * @return the current time in milliseconds, or null if no ntp sync has occurred.
      */
-    fun getCurrentNtpTimeMs(): Long?
+    fun getCachedNtpTimeMs(): Long?
 
     /**
      * @return [KronosTime] for the current time

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
@@ -20,5 +20,5 @@ internal class KronosClockImpl(private val ntpService: SntpService, private val 
         return currentTime ?: KronosTime(posixTimeMs = fallbackClock.getCurrentTimeMs(), timeSinceLastNtpSyncMs = null)
     }
 
-    override fun getCurrentNtpTimeMs() : Long? = ntpService.currentTime()?.posixTimeMs
+    override fun getCachedNtpTimeMs() : Long? = ntpService.cachedTime()?.posixTimeMs
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
@@ -20,5 +20,5 @@ internal class KronosClockImpl(private val ntpService: SntpService, private val 
         return currentTime ?: KronosTime(posixTimeMs = fallbackClock.getCurrentTimeMs(), timeSinceLastNtpSyncMs = null)
     }
 
-    override fun getCachedNtpTimeMs() : Long? = ntpService.cachedTime()?.posixTimeMs
+    override fun getCachedNtpTimeMs() : Long? = ntpService.cachedTime()
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
@@ -51,10 +51,11 @@ internal interface SntpService {
      *
      * Unlike the [currentTime], [syncInBackground] will not called.
      * Outdated values are represented as null.
+     * This method keep working after calling [shutdown].
      *
      * @return the current time, or null if NTP cannot be reached / hasn't synced
      */
-    fun cachedTime(): KronosTime?
+    fun cachedTime(): Long?
 }
 
 internal class SntpServiceImpl @JvmOverloads constructor(private val sntpClient: SntpClient,
@@ -110,16 +111,14 @@ internal class SntpServiceImpl @JvmOverloads constructor(private val sntpClient:
         return KronosTime(posixTimeMs = response.currentTimeMs, timeSinceLastNtpSyncMs = responseAge)
     }
 
-    override fun cachedTime(): KronosTime? {
-        ensureServiceIsRunning()
-
+    override fun cachedTime(): Long? {
         val response = response ?: return null
         val responseAge = response.responseAge
         if (responseAge >= cacheExpirationMs) {
             return null
         }
 
-        return KronosTime(posixTimeMs = response.currentTimeMs, timeSinceLastNtpSyncMs = responseAge)
+        return response.currentTimeMs
     }
 
     override fun syncInBackground() {

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
@@ -15,22 +15,6 @@ import java.util.concurrent.atomic.AtomicReference
 internal interface SntpService {
 
     /**
-     * Return the current time in millisecond.
-     *
-     * If NTP server cannot be reached or if it hasn't yet synced up to the NTP server,
-     * it will return [Constants.TIME_UNAVAILABLE] instead.
-     *
-     * Note calling this method will trigger [syncInBackground] being called when necessary.
-     * You should still call [sync]/[syncInBackground] once to ensure you have the correct
-     * as soon as possible. By default [sync] will be triggered at most once a minute.
-     *
-     * @return the current time in milliseconds.
-     */
-    fun currentTimeMs(): Long {
-        return this.currentTime()?.posixTimeMs ?: Constants.TIME_UNAVAILABLE
-    }
-
-    /**
      * Calls [sync] in a background thread. This method returns immediately.
      */
     fun syncInBackground()
@@ -52,11 +36,25 @@ internal interface SntpService {
     fun shutdown()
 
     /**
-     * Same as currentTimeMs(), but returned object includes time since last ntp sync.
+     * Returned object includes time since last ntp sync.
+     *
+     * Note calling this method will trigger [syncInBackground] being called when necessary.
+     * You should still call [sync]/[syncInBackground] once to ensure you have the correct
+     * as soon as possible. By default [sync] will be triggered at most once a minute.
      *
      * @return the current time, or null if NTP cannot be reached / hasn't synced
      */
     fun currentTime(): KronosTime?
+
+    /**
+     * Returned object includes time since last ntp sync.
+     *
+     * Unlike the [currentTime], [syncInBackground] will not called.
+     * Outdated values are represented as null.
+     *
+     * @return the current time, or null if NTP cannot be reached / hasn't synced
+     */
+    fun cachedTime(): KronosTime?
 }
 
 internal class SntpServiceImpl @JvmOverloads constructor(private val sntpClient: SntpClient,
@@ -107,6 +105,18 @@ internal class SntpServiceImpl @JvmOverloads constructor(private val sntpClient:
         val responseAge = response.responseAge
         if (responseAge >= cacheExpirationMs && cacheSyncAge >= minWaitTimeBetweenSyncMs) {
             syncInBackground()
+        }
+
+        return KronosTime(posixTimeMs = response.currentTimeMs, timeSinceLastNtpSyncMs = responseAge)
+    }
+
+    override fun cachedTime(): KronosTime? {
+        ensureServiceIsRunning()
+
+        val response = response ?: return null
+        val responseAge = response.responseAge
+        if (responseAge >= cacheExpirationMs) {
+            return null
         }
 
         return KronosTime(posixTimeMs = response.currentTimeMs, timeSinceLastNtpSyncMs = responseAge)

--- a/kronos-java/src/test/java/com/lyft/kronos/internal/KronosClockTest.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/internal/KronosClockTest.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 class KronosClockTest {
@@ -49,5 +50,18 @@ class KronosClockTest {
 
         assertThat(kronosClock.getElapsedTimeMs()).isEqualTo(1234L)
         verify(deviceClock).getElapsedTimeMs()
+    }
+
+    @Test
+    fun `cachedNtpTimeMs should always delegate`() {
+        whenever(ntpService.cachedTime()).thenReturn(null)
+
+        assertThat(kronosClock.getCachedNtpTimeMs()).isNull()
+        verify(ntpService).cachedTime()
+
+        whenever(ntpService.cachedTime()).thenReturn(KronosTime(1234L, 1234L))
+
+        assertThat(kronosClock.getCachedNtpTimeMs()).isEqualTo(1234L)
+        verify(ntpService, times(2)).cachedTime()
     }
 }

--- a/kronos-java/src/test/java/com/lyft/kronos/internal/KronosClockTest.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/internal/KronosClockTest.kt
@@ -59,7 +59,7 @@ class KronosClockTest {
         assertThat(kronosClock.getCachedNtpTimeMs()).isNull()
         verify(ntpService).cachedTime()
 
-        whenever(ntpService.cachedTime()).thenReturn(KronosTime(1234L, 1234L))
+        whenever(ntpService.cachedTime()).thenReturn(1234L)
 
         assertThat(kronosClock.getCachedNtpTimeMs()).isEqualTo(1234L)
         verify(ntpService, times(2)).cachedTime()

--- a/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpServiceTest.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpServiceTest.kt
@@ -63,7 +63,6 @@ class SntpServiceTest {
         assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.sync() }
         assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.syncInBackground() }
         assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.currentTime() }
-        assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.cachedTime() }
     }
 
     @Test

--- a/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpServiceTest.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpServiceTest.kt
@@ -62,7 +62,8 @@ class SntpServiceTest {
         verify(sntpClient, never()).requestTime(any(), any())
         assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.sync() }
         assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.syncInBackground() }
-        assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.currentTimeMs() }
+        assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.currentTime() }
+        assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { sntpService.cachedTime() }
     }
 
     @Test


### PR DESCRIPTION
Sometimes it is necessary to get accurate time (or null) without starting automatic synchronization. If time synchronization depends on user actions, re-run can be cancelled. The listener is inconvenient to use when time is requested from several places. The documentation was misleading, in reality it was not possible to get accurate time without synchronization with the server. See issues #36.

⚠️ This change breaks backward compatibility with KronosClock interface. Now its documentation is clear.