### PR TITLE
Migrate to AndroidX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ android:
     - android-15
     - android-17
     - android-27
+    - android-28
   licenses:
     - 'android-sdk-license-.+'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     buildToolsVersion versions.buildTools
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.lyft.kronos.demo"
         minSdkVersion 17
@@ -21,8 +21,8 @@ android {
 
 dependencies {
     implementation project(':kronos-android')
-    implementation "com.android.support:appcompat-v7:$support_lib_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/java/com/lyft/kronos/demo/MainActivity.kt
+++ b/app/src/main/java/com/lyft/kronos/demo/MainActivity.kt
@@ -6,9 +6,9 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
 import android.provider.Settings
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.AppCompatImageButton
 import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.AppCompatImageButton
 import com.lyft.kronos.AndroidClockFactory
 
 class MainActivity : AppCompatActivity() {
@@ -23,9 +23,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun bindSettingsButton() {
-        findViewById<AppCompatImageButton>(R.id.settings_button).setOnClickListener({
+        findViewById<AppCompatImageButton>(R.id.settings_button).setOnClickListener {
             startActivity(Intent(Settings.ACTION_DATE_SETTINGS))
-        })
+        }
     }
 
     private fun bindDeviceClock() {

--- a/app/src/main/java/com/lyft/kronos/demo/TextClock.kt
+++ b/app/src/main/java/com/lyft/kronos/demo/TextClock.kt
@@ -3,13 +3,14 @@ package com.lyft.kronos.demo
 import android.content.Context
 import android.os.SystemClock
 import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
 import com.lyft.kronos.Clock
 import com.lyft.kronos.AndroidClockFactory
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-class TextClock : android.support.v7.widget.AppCompatTextView {
+class TextClock : AppCompatTextView{
 
     var clock : Clock = AndroidClockFactory.createDeviceClock()
 
@@ -20,9 +21,9 @@ class TextClock : android.support.v7.widget.AppCompatTextView {
         }
     }
 
-    constructor(context: Context?) : super(context)
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
@@ -82,17 +82,17 @@
         app:layout_constraintStart_toStartOf="@+id/guideline_vertical_center"
         app:layout_constraintTop_toBottomOf="@+id/kronos_clock_title" />
 
-    <android.support.constraint.Guideline
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline_vertical_center"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.5" />
 
-    <android.support.constraint.Guideline
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline_clocks"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.2"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 
 buildscript {
     ext.kotlin_version = '1.3.21'
-    ext.support_lib_version = '27.1.1'
     repositories {
         google()
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true

--- a/kronos-java/build.gradle
+++ b/kronos-java/build.gradle
@@ -4,7 +4,7 @@ apply from: "$rootDir/gradle/publish-java.gradle"
 
 dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "com.android.support:support-annotations:$support_lib_version"
+    implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
@@ -1,6 +1,6 @@
 package com.lyft.kronos.internal.ntp
 
-import android.support.annotation.WorkerThread
+import androidx.annotation.WorkerThread
 import com.lyft.kronos.Clock
 import com.lyft.kronos.DefaultParam.CACHE_EXPIRATION_MS
 import com.lyft.kronos.DefaultParam.MIN_WAIT_TIME_BETWEEN_SYNC_MS


### PR DESCRIPTION
Fix: #41

This library is almost the last one which blocks us from dropping Jetifier. 