### PR TITLE
Remove Android-specific annotation from the JVM artifact

### DIFF
--- a/kronos-java/build.gradle
+++ b/kronos-java/build.gradle
@@ -4,7 +4,6 @@ apply from: "$rootDir/gradle/publish-java.gradle"
 
 dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "com.android.support:support-annotations:$support_lib_version"
 
     testImplementation 'junit:junit:4.12'
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpService.kt
@@ -1,6 +1,5 @@
 package com.lyft.kronos.internal.ntp
 
-import android.support.annotation.WorkerThread
 import com.lyft.kronos.Clock
 import com.lyft.kronos.DefaultParam.CACHE_EXPIRATION_MS
 import com.lyft.kronos.DefaultParam.MIN_WAIT_TIME_BETWEEN_SYNC_MS
@@ -143,7 +142,6 @@ internal class SntpServiceImpl @JvmOverloads constructor(private val sntpClient:
         }
     }
 
-    @WorkerThread
     private fun sync(host: String): Boolean {
         if (state.getAndSet(State.SYNCING) != State.SYNCING) {
             val t1 = deviceClock.getElapsedTimeMs()


### PR DESCRIPTION
The project is a bit stale, AndroidX came out a long time ago and we are still on the support-level dependencies. However, instead of using AndroidX I suggest to remove support dependencies altogether. This will be better from the maintenance POV.

This change removes an Android-specific annotation from a JVM (Java) artifact. Also the annotation was set on an internal class nobody should use in the first place. 

PTAL @ameliariely, @amphora001, @artem-zinnatullin 