### PR TITLE
Remove Android support dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,6 @@ android {
 
 dependencies {
     implementation project(':kronos-android')
-    implementation "com.android.support:appcompat-v7:$support_lib_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/java/com/lyft/kronos/demo/MainActivity.kt
+++ b/app/src/main/java/com/lyft/kronos/demo/MainActivity.kt
@@ -1,17 +1,17 @@
 package com.lyft.kronos.demo
 
+import android.app.Activity
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
 import android.provider.Settings
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.AppCompatImageButton
 import android.util.Log
+import android.widget.ImageButton
 import com.lyft.kronos.AndroidClockFactory
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,9 +23,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun bindSettingsButton() {
-        findViewById<AppCompatImageButton>(R.id.settings_button).setOnClickListener({
+        findViewById<ImageButton>(R.id.settings_button).setOnClickListener {
             startActivity(Intent(Settings.ACTION_DATE_SETTINGS))
-        })
+        }
     }
 
     private fun bindDeviceClock() {

--- a/app/src/main/java/com/lyft/kronos/demo/TextClock.kt
+++ b/app/src/main/java/com/lyft/kronos/demo/TextClock.kt
@@ -3,13 +3,14 @@ package com.lyft.kronos.demo
 import android.content.Context
 import android.os.SystemClock
 import android.util.AttributeSet
+import android.widget.TextView
 import com.lyft.kronos.Clock
 import com.lyft.kronos.AndroidClockFactory
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-class TextClock : android.support.v7.widget.AppCompatTextView {
+class TextClock : TextView {
 
     var clock : Clock = AndroidClockFactory.createDeviceClock()
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,98 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/root_layout"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/description_text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/span8"
-        android:layout_marginEnd="@dimen/span8"
-        android:layout_marginStart="@dimen/span8"
-        android:layout_marginTop="@dimen/span8"
-        android:maxLines="4"
-        android:text="@string/description_text"
-        app:layout_constraintBottom_toTopOf="@+id/guideline_clocks"
-        app:layout_constraintEnd_toStartOf="@+id/settings_button"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <ImageButton
-        android:id="@+id/settings_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/span8"
-        android:layout_marginEnd="@dimen/span8"
-        android:layout_marginTop="@dimen/span8"
-        android:src="@android:drawable/ic_menu_preferences"
-        app:layout_constraintBottom_toTopOf="@+id/guideline_clocks"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:contentDescription="@string/date_and_time_settings" />
-
-
-    <TextView
-        android:id="@+id/android_clock_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/span8"
-        android:layout_marginStart="@dimen/span8"
-        android:text="@string/android_clock"
-        app:layout_constraintEnd_toStartOf="@+id/guideline_vertical_center"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guideline_clocks" />
-
-    <com.lyft.kronos.demo.TextClock
-        android:id="@+id/android_clock"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/span8"
-        android:layout_marginStart="@dimen/span8"
-        android:layout_marginTop="@dimen/span8"
-        android:gravity="center"
-        app:layout_constraintEnd_toStartOf="@+id/guideline_vertical_center"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/android_clock_title" />
-
-    <TextView
-        android:id="@+id/kronos_clock_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/span8"
-        android:layout_marginStart="@dimen/span8"
-        android:text="@string/kronos_clock"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/guideline_vertical_center"
-        app:layout_constraintTop_toTopOf="@+id/guideline_clocks" />
-
-    <com.lyft.kronos.demo.TextClock
-        android:id="@+id/kronos_clock"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/span8"
-        android:layout_marginStart="@dimen/span8"
-        android:layout_marginTop="@dimen/span8"
-        android:gravity="center"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/guideline_vertical_center"
-        app:layout_constraintTop_toBottomOf="@+id/kronos_clock_title" />
-
-    <android.support.constraint.Guideline
-        android:id="@+id/guideline_vertical_center"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.5" />
-
-    <android.support.constraint.Guideline
-        android:id="@+id/guideline_clocks"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <LinearLayout
+        android:layout_margin="16dp"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.2"/>
-</android.support.constraint.ConstraintLayout>
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:text="@string/description_text"
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content" />
+
+        <Space
+            android:layout_width="16dp"
+            android:layout_height="0dp" />
+
+        <ImageButton
+            android:id="@+id/settings_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/span8"
+            android:layout_marginEnd="@dimen/span8"
+            android:layout_marginTop="@dimen/span8"
+            android:src="@android:drawable/ic_menu_preferences"
+            android:contentDescription="@string/date_and_time_settings" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:text="@string/android_clock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <com.lyft.kronos.demo.TextClock
+                android:id="@+id/android_clock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:text="@string/kronos_clock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <com.lyft.kronos.demo.TextClock
+                android:id="@+id/kronos_clock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,9 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+    <style name="AppTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:colorPrimary" tools:targetApi="21">@color/colorPrimary</item>
+        <item name="android:colorPrimaryDark" tools:targetApi="21">@color/colorPrimaryDark</item>
+        <item name="android:colorAccent" tools:targetApi="21">@color/colorAccent</item>
     </style>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 
 buildscript {
     ext.kotlin_version = '1.3.21'
-    ext.support_lib_version = '27.1.1'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Done to avoid maintaining AndroidX / Android support dependencies and forcing consumers to use Jetifier. Similar to #43.

Screenshots of the demo application:

* [without applied patch](https://user-images.githubusercontent.com/200401/98722825-97008580-23a2-11eb-9cb6-a2f6e2200f36.png);
* [with applied patch](https://user-images.githubusercontent.com/200401/98722856-a41d7480-23a2-11eb-9372-49d72f7211af.png).

We are losing the toolbar since the minimum SDK is set to `17` (Android 4.2). Shouldn’t be a huge loss since it’s a demo application.

PTAL @ameliariely @buildbreaker 
