### PR TITLE
Filter out long latency responses to increase accuracy

### DIFF
--- a/kronos-android/src/main/java/com/lyft/kronos/AndroidClockFactory.kt
+++ b/kronos-android/src/main/java/com/lyft/kronos/AndroidClockFactory.kt
@@ -2,6 +2,7 @@ package com.lyft.kronos
 
 import android.content.Context
 import com.lyft.kronos.DefaultParam.CACHE_EXPIRATION_MS
+import com.lyft.kronos.DefaultParam.MAX_NTP_RESPONSE_TIME_MS
 import com.lyft.kronos.DefaultParam.MIN_WAIT_TIME_BETWEEN_SYNC_MS
 import com.lyft.kronos.DefaultParam.NTP_HOSTS
 import com.lyft.kronos.DefaultParam.TIMEOUT_MS
@@ -22,11 +23,12 @@ object AndroidClockFactory {
                           ntpHosts: List<String> = NTP_HOSTS,
                           requestTimeoutMs: Long = TIMEOUT_MS,
                           minWaitTimeBetweenSyncMs: Long = MIN_WAIT_TIME_BETWEEN_SYNC_MS,
-                          cacheExpirationMs: Long = CACHE_EXPIRATION_MS): KronosClock {
+                          cacheExpirationMs: Long = CACHE_EXPIRATION_MS,
+                          maxNtpResponseTimeMs: Long = MAX_NTP_RESPONSE_TIME_MS): KronosClock {
 
         val deviceClock = createDeviceClock()
         val cache = SharedPreferenceSyncResponseCache(context.getSharedPreferences(SharedPreferenceSyncResponseCache.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE))
 
-        return ClockFactory.createKronosClock(deviceClock, cache, syncListener, ntpHosts, requestTimeoutMs, minWaitTimeBetweenSyncMs, cacheExpirationMs)
+        return ClockFactory.createKronosClock(deviceClock, cache, syncListener, ntpHosts, requestTimeoutMs, minWaitTimeBetweenSyncMs, cacheExpirationMs, maxNtpResponseTimeMs)
     }
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/DefaultParam.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/DefaultParam.kt
@@ -3,10 +3,11 @@ package com.lyft.kronos
 import java.util.concurrent.TimeUnit
 
 object DefaultParam {
-    val NTP_HOSTS = listOf("2.us.pool.ntp.org", "1.us.pool.ntp.org", "0.us.pool.ntp.org")
+    val NTP_HOSTS = listOf("2.us.pool.ntp.org", "1.us.pool.ntp.org", "0.us.pool.ntp.org", "pool.ntp.org")
     // Sync with NTP if the cache is older than this value
     val CACHE_EXPIRATION_MS = TimeUnit.MINUTES.toMillis(1)
     // Sync with NTP only after MIN_WAIT_TIME_BETWEEN_SYNC_MS regardless of success or failure
     val MIN_WAIT_TIME_BETWEEN_SYNC_MS = TimeUnit.MINUTES.toMillis(1)
     val TIMEOUT_MS = TimeUnit.SECONDS.toMillis(6)
+    val MAX_NTP_RESPONSE_TIME_MS = TimeUnit.SECONDS.toMillis(5)
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/DefaultParam.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/DefaultParam.kt
@@ -3,7 +3,7 @@ package com.lyft.kronos
 import java.util.concurrent.TimeUnit
 
 object DefaultParam {
-    val NTP_HOSTS = listOf("2.us.pool.ntp.org", "1.us.pool.ntp.org", "0.us.pool.ntp.org", "pool.ntp.org")
+    val NTP_HOSTS = listOf("2.us.pool.ntp.org", "1.us.pool.ntp.org", "0.us.pool.ntp.org")
     // Sync with NTP if the cache is older than this value
     val CACHE_EXPIRATION_MS = TimeUnit.MINUTES.toMillis(1)
     // Sync with NTP only after MIN_WAIT_TIME_BETWEEN_SYNC_MS regardless of success or failure

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/NTPSyncException.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/NTPSyncException.kt
@@ -2,4 +2,4 @@ package com.lyft.kronos.internal.ntp
 
 import java.lang.RuntimeException
 
-class NTPSyncException(message: String) : RuntimeException(message)
+open class NTPSyncException(message: String) : RuntimeException(message)

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/NTPSyncException.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/NTPSyncException.kt
@@ -2,4 +2,4 @@ package com.lyft.kronos.internal.ntp
 
 import java.lang.RuntimeException
 
-open class NTPSyncException(message: String) : RuntimeException(message)
+class NTPSyncException(message: String) : RuntimeException(message)


### PR DESCRIPTION
Adding a filter to ignore response with long delay. The default value of 5 seconds is conservatively set to fit the use case of the Lyft app.