### PR TITLE
Change default NTP servers from US to international ones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Kronos comes with a set of reasonable default configurations. You can customize 
 * `syncListener` 
     * Allows you to log sync operation successes and errors, which maybe useful for custom analytics. Pass an implementation of `SyncListener`.
 * `ntpHosts`
-    * Specify a list of NTP servers with which to sync.
+    * Specify a list of NTP servers with which to sync. Default servers are set to [the NTP pool](https://www.ntppool.org/en/use.html).
 * `requestTimeoutMs`
     * Lengthen or shorten the timeout value. If the NTP server fails to respond within the given time, the next server will be contacted. If none of the server respond within the given time, the sync operation will be considered a failure.
 * `minWaitTimeBetweenSyncMs`

--- a/kronos-java/src/main/java/com/lyft/kronos/DefaultParam.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/DefaultParam.kt
@@ -3,7 +3,7 @@ package com.lyft.kronos
 import java.util.concurrent.TimeUnit
 
 object DefaultParam {
-    val NTP_HOSTS = listOf("2.us.pool.ntp.org", "1.us.pool.ntp.org", "0.us.pool.ntp.org")
+    val NTP_HOSTS = listOf("0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org")
     // Sync with NTP if the cache is older than this value
     val CACHE_EXPIRATION_MS = TimeUnit.MINUTES.toMillis(1)
     // Sync with NTP only after MIN_WAIT_TIME_BETWEEN_SYNC_MS regardless of success or failure

--- a/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpServiceTest.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpServiceTest.kt
@@ -17,7 +17,7 @@ class SntpServiceTest {
     private val responseCache = mock<SntpResponseCache>()
     private val sntpSyncListener = mock<SyncListener>()
     private val mockResponse = mock<SntpClient.Response>()
-    private val ntpHosts = listOf("2.us.pool.ntp.org", "1.us.pool.ntp.org", "0.us.pool.ntp.org")
+    private val ntpHosts = listOf("2.fake.pool.ntp.org", "1.fake.pool.ntp.org", "0.fake.pool.ntp.org")
 
     init {
         whenever(deviceClock.getElapsedTimeMs()).then({ System.currentTimeMillis() })
@@ -32,27 +32,27 @@ class SntpServiceTest {
         assertThat(sntpService.sync()).isFalse()
 
         verify(sntpSyncListener, times(3)).onStartSync(any())
-        verify(sntpSyncListener, times(1)).onError("2.us.pool.ntp.org", mockError)
-        verify(sntpSyncListener, times(1)).onError("1.us.pool.ntp.org", mockError)
-        verify(sntpSyncListener, times(1)).onError("0.us.pool.ntp.org", mockError)
+        verify(sntpSyncListener, times(1)).onError("2.fake.pool.ntp.org", mockError)
+        verify(sntpSyncListener, times(1)).onError("1.fake.pool.ntp.org", mockError)
+        verify(sntpSyncListener, times(1)).onError("0.fake.pool.ntp.org", mockError)
 
         whenever(sntpClient.requestTime(any(), any())).thenReturn(mockResponse)
         assertThat(sntpService.sync()).isTrue
 
-        verify(sntpSyncListener, times(2)).onStartSync("2.us.pool.ntp.org")
+        verify(sntpSyncListener, times(2)).onStartSync("2.fake.pool.ntp.org")
         verify(sntpSyncListener, times(1)).onSuccess(any(), any())
     }
 
     @Test
     fun testOneOfThreeServerHasError() {
         val mockError = mock<IOException>()
-        whenever(sntpClient.requestTime("2.us.pool.ntp.org", TIMEOUT_MS)).thenThrow(mockError)
-        whenever(sntpClient.requestTime("1.us.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
+        whenever(sntpClient.requestTime("2.fake.pool.ntp.org", TIMEOUT_MS)).thenThrow(mockError)
+        whenever(sntpClient.requestTime("1.fake.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
         assertThat(sntpService.sync()).isTrue
 
-        verify(sntpSyncListener, times(1)).onStartSync("2.us.pool.ntp.org")
-        verify(sntpSyncListener, times(1)).onError("2.us.pool.ntp.org", mockError)
-        verify(sntpSyncListener, times(1)).onStartSync("1.us.pool.ntp.org")
+        verify(sntpSyncListener, times(1)).onStartSync("2.fake.pool.ntp.org")
+        verify(sntpSyncListener, times(1)).onError("2.fake.pool.ntp.org", mockError)
+        verify(sntpSyncListener, times(1)).onStartSync("1.fake.pool.ntp.org")
         verify(sntpSyncListener, times(1)).onSuccess(any(), any())
     }
 
@@ -64,13 +64,13 @@ class SntpServiceTest {
                 .thenReturn(now + MAX_NTP_RESPONSE_TIME_MS + 1) //first response time
                 .thenReturn(now + MAX_NTP_RESPONSE_TIME_MS + 10) //second request time
                 .thenReturn(now + MAX_NTP_RESPONSE_TIME_MS + 50) //second response time
-        whenever(sntpClient.requestTime("2.us.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
-        whenever(sntpClient.requestTime("1.us.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
+        whenever(sntpClient.requestTime("2.fake.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
+        whenever(sntpClient.requestTime("1.fake.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
         assertThat(sntpService.sync()).isTrue
 
-        verify(sntpSyncListener, times(1)).onStartSync("2.us.pool.ntp.org")
-        verify(sntpSyncListener, times(1)).onError(eq("2.us.pool.ntp.org"), any<NTPSyncException>())
-        verify(sntpSyncListener, times(1)).onStartSync("1.us.pool.ntp.org")
+        verify(sntpSyncListener, times(1)).onStartSync("2.fake.pool.ntp.org")
+        verify(sntpSyncListener, times(1)).onError(eq("2.fake.pool.ntp.org"), any<NTPSyncException>())
+        verify(sntpSyncListener, times(1)).onStartSync("1.fake.pool.ntp.org")
         verify(sntpSyncListener, times(1)).onSuccess(any(), any())
     }
 
@@ -85,13 +85,13 @@ class SntpServiceTest {
 
     @Test
     fun `throw error if response has negative time value`() {
-        whenever(sntpClient.requestTime("1.us.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
-        whenever(sntpClient.requestTime("2.us.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
+        whenever(sntpClient.requestTime("1.fake.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
+        whenever(sntpClient.requestTime("2.fake.pool.ntp.org", TIMEOUT_MS)).thenReturn(mockResponse)
         whenever(mockResponse.currentTimeMs).thenReturn(-1)
 
         assertThat(sntpService.sync()).isFalse
 
-        verify(sntpSyncListener, times(1)).onError(eq("1.us.pool.ntp.org"), any<NTPSyncException>())
-        verify(sntpSyncListener, times(1)).onError(eq("2.us.pool.ntp.org"), any<NTPSyncException>())
+        verify(sntpSyncListener, times(1)).onError(eq("1.fake.pool.ntp.org"), any<NTPSyncException>())
+        verify(sntpSyncListener, times(1)).onError(eq("2.fake.pool.ntp.org"), any<NTPSyncException>())
     }
 }


### PR DESCRIPTION
Addresses [the comment from a previous PR](https://github.com/lyft/Kronos-Android/pull/48#discussion_r525370674).

Server addresses given to me at Minsk are from Belarus. Meaning the pool seem to provide not random addresses (like [the NTP page mentions](https://www.ntppool.org/en/use.html)) but localized ones.

PTAL @buildbreaker, @ameliariely, @amphora001 