### PR TITLE
Add Kotlin-based NTP packet decoding

### DIFF
--- a/kronos-java/build.gradle
+++ b/kronos-java/build.gradle
@@ -10,4 +10,6 @@ dependencies {
     testImplementation "org.mockito:mockito-core:3.6.0"
     testImplementation "org.mockito:mockito-inline:3.6.0"
     testImplementation "org.assertj:assertj-core:3.18.1"
+
+    testImplementation("com.squareup.okio:okio:2.10.0")
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/ntp/NtpPacket.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/ntp/NtpPacket.kt
@@ -1,0 +1,95 @@
+package com.lyft.kronos.ntp
+
+internal data class NtpPacket(
+
+    /**
+     * A warning of an impending leap second to be inserted / deleted
+     * in the last minute of the current day.
+     */
+    val warningLeapSecond: Byte,
+
+    val protocolVersion: Byte,
+
+    val protocolMode: Byte,
+
+    /**
+     * The stratum level of the local clock.
+     */
+    val stratum: Byte,
+
+    /**
+     * Used as a power of two, where the resulting value is
+     * the maximum interval between successive messages in seconds.
+     * Values range from 4 (16 seconds) to 17 (131072 seconds: about 36 hours).
+     */
+    val maximumPollIntervalPowerOfTwo: Byte,
+
+    /**
+     * Used as an exponent of two, where the resulting value is
+     * the precision of the system clock in seconds.
+     * Values range from -6 for mains-frequency clocks to -20 for microsecond clocks found in some workstations.
+     */
+    val precisionPowerOfTwo: Byte,
+
+    /**
+     * The number indicating the total roundtrip delay to the primary reference source.
+     * Note that this variable can take on both positive and negative values, depending on
+     * the relative time and frequency offsets.
+     * Values range from negative values of a few milliseconds to positive values of several hundred milliseconds.
+     */
+    val rootDelaySeconds: Double,
+
+    /**
+     * The number indicating the maximum error due to the clock frequency tolerance.
+     * Values range from zero to several hundred milliseconds.
+     */
+    val rootDispersionSeconds: Double,
+
+    /**
+     * The time the system clock was last set or corrected.
+     */
+    val referenceTimeSecondsSince1900: Double,
+
+    /**
+     * The time at which the request departed the client for the server.
+     */
+    val originateTimeSecondsSince1900: Double,
+
+    /**
+     * The time at which the request arrived at the server or the reply arrived at the client.
+     */
+    val receiveTimeSecondsSince1900: Double,
+
+    /**
+     * The time at which the request departed the client or the reply departed the server.
+     */
+    val transmitTimeSecondsSince1900: Double
+
+) {
+
+    enum class WarningLeapSecond(val value: Byte) {
+        NoWarning(0),
+        WarningLastMinuteHas61Seconds(1),
+        WarningLastMinuteHas59Seconds(2),
+        AlertClockUnsynchronized(3),
+    }
+
+    enum class ProtocolMode(val value: Byte) {
+        Reserved(0),
+        SymmetricActive(1),
+        SymmetricPassive(2),
+        Client(3),
+        Server(4),
+        Broadcast(5),
+        ReservedNtp(6),
+        ReservedPrivate(7),
+    }
+
+    enum class Stratum(val valueFrom: Byte, val valueTill: Byte) {
+        KissOfDeath(0, 0),
+        PrimaryReference(1, 1),
+        SecondaryReference(2, 25),
+        Reserved(16, 127),
+    }
+
+}

--- a/kronos-java/src/main/java/com/lyft/kronos/ntp/NtpPackets.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/ntp/NtpPackets.kt
@@ -1,0 +1,58 @@
+package com.lyft.kronos.ntp
+
+import java.nio.ByteBuffer
+
+internal interface NtpPackets {
+
+    fun decode(packetBuffer: ByteBuffer): NtpPacket
+
+    class Impl : NtpPackets {
+
+        // Source of truth (SNTP 4): https://tools.ietf.org/html/rfc4330
+
+        override fun decode(packetBuffer: ByteBuffer) = NtpPacket(
+            warningLeapSecond = (packetBuffer.get(0).toInt().shr(6) and 3).toByte(),
+            protocolVersion = (packetBuffer.get(0).toInt().shr(3) and 7).toByte(),
+            protocolMode = (packetBuffer.get(0).toInt() and 7).toByte(),
+            stratum = packetBuffer.get(1),
+            maximumPollIntervalPowerOfTwo = packetBuffer.get(2),
+            precisionPowerOfTwo = packetBuffer.get(3),
+            rootDelaySeconds = packetBuffer.intervalSeconds(4),
+            rootDispersionSeconds = packetBuffer.intervalSeconds(8),
+            referenceTimeSecondsSince1900 = packetBuffer.timeSeconds(16),
+            originateTimeSecondsSince1900 = packetBuffer.timeSeconds(24),
+            receiveTimeSecondsSince1900 = packetBuffer.timeSeconds(32),
+            transmitTimeSecondsSince1900 = packetBuffer.timeSeconds(40),
+        )
+
+        private fun ByteBuffer.intervalSeconds(position: Int): Double {
+            val integer = getUInt16(position)
+            val decimal = getUInt16Decimal(position + 2)
+
+            return integer + decimal
+        }
+
+        private fun ByteBuffer.timeSeconds(position: Int): Double {
+            val seconds = getUInt32(position)
+            val secondsFraction = getUInt32Decimal(position + 4)
+
+            return seconds + secondsFraction
+        }
+
+        private fun ByteBuffer.getUInt16(position: Int): Int = this
+            .getShort(position)
+            .toInt()
+            .and(0xffff)
+
+        private fun ByteBuffer.getUInt16Decimal(position: Int): Double = getUInt16(position)
+            .toDouble() / (0xffff + 1)
+
+        private fun ByteBuffer.getUInt32(position: Int): Long = this
+            .getInt(position)
+            .toLong()
+            .and(0xffffffff)
+
+        private fun ByteBuffer.getUInt32Decimal(position: Int): Double = getUInt32(position)
+            .toDouble() / (0xffffffff + 1)
+    }
+}

--- a/kronos-java/src/test/java/com/lyft/kronos/ntp/NtpPacketsTests.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/ntp/NtpPacketsTests.kt
@@ -1,0 +1,120 @@
+package com.lyft.kronos.ntp
+
+import okio.ByteString.Companion.decodeHex
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class NtpPacketsTests {
+
+    private val packets by lazy { NtpPackets.Impl() }
+
+    // Decode
+
+    // Use following commands to produce independent package picture.
+    //
+    // $ sudo tcpdump port 123 -vv -X
+    // $ sntp REPLACE_ME_WITH_NTP_HOST
+    //
+    // tcpdump will output both raw hex package (last 24 hex blocks are 48 NTP bytes)
+    // and resolved NTP properties. This information can be used to produce good test data.
+
+    @Test
+    fun decodeApple() {
+        // time.apple.com
+
+        val packetHex = "240108eb000000000000000c53484d00e3d28d742a667f0ee3d28d7982281345e3d28d798912f961e3d28d7989138fec"
+
+        val packet = NtpPacket(
+            warningLeapSecond = 0,
+            protocolVersion = 4,
+            protocolMode = 4,
+            stratum = 1,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = -21,
+            rootDelaySeconds = 0.0,
+            rootDispersionSeconds = 0.00018310546875,
+            referenceTimeSecondsSince1900 = 3822226804.165626469,
+            originateTimeSecondsSince1900 = 3822226809.508424000,
+            receiveTimeSecondsSince1900 = 3822226809.535445772,
+            transmitTimeSecondsSince1900 = 3822226809.535454745,
+        )
+
+        assertDecode(packetHex, packet)
+    }
+
+    @Test
+    fun decodeAppleEuro() {
+        // time.euro.apple.com
+
+        val packetHex = "240108eb000000000000000753484d00e3d267942a6608b7e3d26794e740b34ee3d26794ebdf5990e3d26794ebe060d7"
+
+        val packet = NtpPacket(
+            warningLeapSecond = 0,
+            protocolVersion = 4,
+            protocolMode = 4,
+            stratum = 1,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = -21,
+            rootDelaySeconds = 0.0,
+            rootDispersionSeconds = 0.0001068115234375,
+            referenceTimeSecondsSince1900 = 3822217108.165619415,
+            originateTimeSecondsSince1900 = 3822217108.903330999,
+            receiveTimeSecondsSince1900 = 3822217108.921376798,
+            transmitTimeSecondsSince1900 = 3822217108.921392490,
+        )
+
+        assertDecode(packetHex, packet)
+    }
+
+    @Test
+    fun decodeGoogle() {
+        // time.google.com
+
+        val packetHex = "240108ec0000000000000006474f4f47e3d28fbacdae52f4e3d28fbac48d1959e3d28fbacdae52f5e3d28fbacdae52f7"
+
+        val packet = NtpPacket(
+            warningLeapSecond = 0,
+            protocolVersion = 4,
+            protocolMode = 4,
+            stratum = 1,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = -20,
+            rootDelaySeconds = 0.0,
+            rootDispersionSeconds = 0.000091552734375,
+            referenceTimeSecondsSince1900 = 3822227386.803441223,
+            originateTimeSecondsSince1900 = 3822227386.767778000,
+            receiveTimeSecondsSince1900 = 3822227386.803441223,
+            transmitTimeSecondsSince1900 = 3822227386.803441224,
+        )
+
+        assertDecode(packetHex, packet)
+    }
+
+    @Test
+    fun decodePool() {
+        // pool.ntp.org
+
+        val packetHex = "240208e900000cfa000008fac0356768e3d28bd2102d8729e3d290ea0e1c0443e3d290ea13774710e3d290ea137a40bd"
+
+        val packet = NtpPacket(
+            warningLeapSecond = 0,
+            protocolVersion = 4,
+            protocolMode = 4,
+            stratum = 2,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = -23,
+            rootDelaySeconds = 0.050689697265625,
+            rootDispersionSeconds = 0.035064697265625,
+            referenceTimeSecondsSince1900 = 3822226386.063194701,
+            originateTimeSecondsSince1900 = 3822227690.055115000,
+            receiveTimeSecondsSince1900 = 3822227690.076038781,
+            transmitTimeSecondsSince1900 = 3822227690.076084180,
+        )
+
+        assertDecode(packetHex, packet)
+    }
+
+    private fun assertDecode(packetHex: String, packet: NtpPacket) {
+        assertThat(packets.decode(packetHex.decodeHex().asByteBuffer())).isEqualTo(packet)
+    }
+}


### PR DESCRIPTION
This is an eventual replacement for `SntpClient.java`.

* No Java code.
  * However, `java.nio.ByteBuffer` is used but it can be replaced with `okio.Buffer` if the multiplatform need arises.
* A lot of tests based on `tcpdump` output across 4 different NTP servers.
* Based on SNTP 4 RFC directly, no copy-paste from other OSS sourcs.

PTAL @buildbreaker @ameliariely @amphora001 