### PR TITLE
Add Kotlin-based NTP packet encoding

### DIFF
--- a/kronos-java/src/main/java/com/lyft/kronos/ntp/ByteBuffer.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/ntp/ByteBuffer.kt
@@ -1,0 +1,33 @@
+package com.lyft.kronos.ntp
+
+import java.nio.ByteBuffer
+
+internal fun ByteBuffer.getUInt16(position: Int): Int = this
+    .getShort(position)
+    .toInt()
+    .and(0xffff)
+
+internal fun ByteBuffer.getUInt16Decimal(position: Int): Double = this
+    .getUInt16(position)
+    .toDouble() / (0xffff + 1)
+
+internal fun ByteBuffer.putUInt16(position: Int, value: Int): ByteBuffer = this
+    .putShort(position, value.toShort())
+
+internal fun ByteBuffer.putUInt16Decimal(position: Int, value: Double): ByteBuffer = this
+    .putUInt16(position, (value * (0xffff + 1)).toInt())
+
+internal fun ByteBuffer.getUInt32(position: Int): Long = this
+    .getInt(position)
+    .toLong()
+    .and(0xffff_ffff)
+
+internal fun ByteBuffer.getUInt32Decimal(position: Int): Double = this
+    .getUInt32(position)
+    .toDouble() / (0xffff_ffff + 1)
+
+internal fun ByteBuffer.putUInt32(position: Int, value: Long): ByteBuffer = this
+    .putInt(position, value.toInt())
+
+internal fun ByteBuffer.putUInt32Decimal(position: Int, value: Double): ByteBuffer = this
+    .putUInt32(position, (value * (0xffff_ffff + 1)).toLong())

--- a/kronos-java/src/test/java/com/lyft/kronos/ntp/ByteBufferTests.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/ntp/ByteBufferTests.kt
@@ -1,0 +1,75 @@
+package com.lyft.kronos.ntp
+
+import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.toByteString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.nio.ByteBuffer
+
+class ByteBufferTests {
+
+    private data class UInt16(val byteBufferHex: String, val value: Double)
+
+    private val valuesUInt16 = listOf(
+        UInt16("00000006", 0.000091552734375),
+        UInt16("00000007", 0.0001068115234375),
+        UInt16("0000000c", 0.00018310546875),
+        UInt16("000008fa", 0.035064697265625),
+        UInt16("00000cfa", 0.050689697265625),
+    )
+
+    @Test
+    fun getUInt16() {
+        valuesUInt16.forEach {
+            val buffer = it.byteBufferHex.decodeHex().asByteBuffer()
+            val value = buffer.getUInt16(0) + buffer.getUInt16Decimal(2)
+
+            assertThat(value).isEqualTo(it.value)
+        }
+    }
+
+    @Test
+    fun putUInt16() {
+        valuesUInt16.forEach {
+            val buffer = ByteBuffer.allocate(4)
+                .putUInt16(0, it.value.toInt())
+                .putUInt16Decimal(2, it.value - it.value.toInt())
+
+            val bufferHex = buffer.toByteString().hex()
+
+            assertThat(bufferHex).isEqualTo(it.byteBufferHex)
+        }
+    }
+
+    private data class UInt32(val byteBufferHex: String, val value: Double)
+
+    private val valuesUInt32 = listOf(
+        UInt32("e3d26794ebe06000", 3822217108.921392490),
+        UInt32("e3d28d7989139000", 3822226809.535454745),
+        UInt32("e3d28fbacdae5000", 3822227386.803441224),
+        UInt32("e3d290ea137a4000", 3822227690.076084180),
+    )
+
+    @Test
+    fun getUInt32() {
+        valuesUInt32.forEach {
+            val buffer = it.byteBufferHex.decodeHex().asByteBuffer()
+            val value = buffer.getUInt32(0) + buffer.getUInt32Decimal(4)
+
+            assertThat(value).isEqualTo(it.value)
+        }
+    }
+
+    @Test
+    fun putUInt32() {
+        valuesUInt32.forEach {
+            val buffer = ByteBuffer.allocate(8)
+                .putUInt32(0, it.value.toLong())
+                .putUInt32Decimal(4, it.value - it.value.toLong())
+
+            val bufferHex = buffer.toByteString().hex()
+
+            assertThat(bufferHex).isEqualTo(it.byteBufferHex)
+        }
+    }
+}

--- a/kronos-java/src/test/java/com/lyft/kronos/ntp/NtpPacketsTests.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/ntp/NtpPacketsTests.kt
@@ -1,14 +1,13 @@
 package com.lyft.kronos.ntp
 
 import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class NtpPacketsTests {
 
     private val packets by lazy { NtpPackets.Impl() }
-
-    // Decode
 
     // Use following commands to produce independent package picture.
     //
@@ -17,6 +16,8 @@ class NtpPacketsTests {
     //
     // tcpdump will output both raw hex package (last 24 hex blocks are 48 NTP bytes)
     // and resolved NTP properties. This information can be used to produce good test data.
+
+    // Decode
 
     @Test
     fun decodeApple() {
@@ -116,5 +117,107 @@ class NtpPacketsTests {
 
     private fun assertDecode(packetHex: String, packet: NtpPacket) {
         assertThat(packets.decode(packetHex.decodeHex().asByteBuffer())).isEqualTo(packet)
+    }
+
+    // Encode
+
+    @Test
+    fun encodeApple() {
+        // time.apple.com
+
+        val packet = NtpPacket(
+            warningLeapSecond = 3,
+            protocolVersion = 4,
+            protocolMode = 3,
+            stratum = 0,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = 0,
+            rootDelaySeconds = 0.0,
+            rootDispersionSeconds = 0.0,
+            referenceTimeSecondsSince1900 = 0.0,
+            originateTimeSecondsSince1900 = 0.0,
+            receiveTimeSecondsSince1900 = 0.0,
+            transmitTimeSecondsSince1900 = 3822666353.398732000,
+        )
+
+        val packetHex = "e3000800000000000000000000000000000000000000000000000000000000000000000000000000e3d9427166135000"
+
+        assertEncode(packetHex, packet)
+    }
+
+    @Test
+    fun encodeAppleEuro() {
+        // time.euro.apple.com
+
+        val packet = NtpPacket(
+            warningLeapSecond = 3,
+            protocolVersion = 4,
+            protocolMode = 3,
+            stratum = 0,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = 0,
+            rootDelaySeconds = 0.0,
+            rootDispersionSeconds = 0.0,
+            referenceTimeSecondsSince1900 = 0.0,
+            originateTimeSecondsSince1900 = 0.0,
+            receiveTimeSecondsSince1900 = 0.0,
+            transmitTimeSecondsSince1900 = 3822666760.277606999,
+        )
+
+        val packetHex = "e3000800000000000000000000000000000000000000000000000000000000000000000000000000e3d9440847114000"
+
+        assertEncode(packetHex, packet)
+    }
+
+    @Test
+    fun encodeGoogle() {
+        // time.google.com
+
+        val packet = NtpPacket(
+            warningLeapSecond = 3,
+            protocolVersion = 4,
+            protocolMode = 3,
+            stratum = 0,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = 0,
+            rootDelaySeconds = 0.0,
+            rootDispersionSeconds = 0.0,
+            referenceTimeSecondsSince1900 = 0.0,
+            originateTimeSecondsSince1900 = 0.0,
+            receiveTimeSecondsSince1900 = 0.0,
+            transmitTimeSecondsSince1900 = 3822666850.665352999,
+        )
+
+        val packetHex = "e3000800000000000000000000000000000000000000000000000000000000000000000000000000e3d94462aa549000"
+
+        assertEncode(packetHex, packet)
+    }
+
+    @Test
+    fun encodePool() {
+        // pool.ntp.org
+
+        val packet = NtpPacket(
+            warningLeapSecond = 3,
+            protocolVersion = 4,
+            protocolMode = 3,
+            stratum = 0,
+            maximumPollIntervalPowerOfTwo = 8,
+            precisionPowerOfTwo = 0,
+            rootDelaySeconds = 0.0,
+            rootDispersionSeconds = 0.0,
+            referenceTimeSecondsSince1900 = 0.0,
+            originateTimeSecondsSince1900 = 0.0,
+            receiveTimeSecondsSince1900 = 0.0,
+            transmitTimeSecondsSince1900 = 3822666922.660100999,
+        )
+
+        val packetHex = "e3000800000000000000000000000000000000000000000000000000000000000000000000000000e3d944aaa8fc6000"
+
+        assertEncode(packetHex, packet)
+    }
+
+    private fun assertEncode(packetHex: String, packet: NtpPacket) {
+        assertThat(packets.encode(packet).toByteString().hex()).isEqualTo(packetHex)
     }
 }


### PR DESCRIPTION
Continues #55.

* Even more tests! Moved `ByteBuffer` extensions to a separate file to allow even more testing on shuffling numbers around which might be tricky sometimes.
* Values under test were captured using `sntp` + `tcpdump` to reflect IRL packet structure and contents.

PTAL @buildbreaker @ameliariely @amphora001