### PR TITLE
Use boot count to detect reboot if it exists

### DIFF
--- a/app/src/main/java/com/lyft/kronos/demo/MainActivity.kt
+++ b/app/src/main/java/com/lyft/kronos/demo/MainActivity.kt
@@ -29,7 +29,7 @@ class MainActivity : Activity() {
     }
 
     private fun bindDeviceClock() {
-        findViewById<TextClock>(R.id.android_clock).clock = AndroidClockFactory.createDeviceClock()
+        findViewById<TextClock>(R.id.android_clock).clock = AndroidClockFactory.createDeviceClock(this)
     }
 
     private fun bindKronosClock() {

--- a/app/src/main/java/com/lyft/kronos/demo/TextClock.kt
+++ b/app/src/main/java/com/lyft/kronos/demo/TextClock.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 
 class TextClock : TextView {
 
-    var clock : Clock = AndroidClockFactory.createDeviceClock()
+    var clock : Clock = AndroidClockFactory.createDeviceClock(context)
 
     private val ticker = object : Runnable {
         override fun run() {

--- a/kronos-android/src/main/java/com/lyft/kronos/AndroidClockFactory.kt
+++ b/kronos-android/src/main/java/com/lyft/kronos/AndroidClockFactory.kt
@@ -14,7 +14,7 @@ object AndroidClockFactory {
      * Create a device clock that uses the OS/device specific API to retrieve time
      */
     @JvmStatic
-    fun createDeviceClock(): Clock = AndroidSystemClock()
+    fun createDeviceClock(context: Context): Clock = AndroidSystemClock(context)
 
     @JvmStatic
     @JvmOverloads
@@ -26,7 +26,7 @@ object AndroidClockFactory {
                           cacheExpirationMs: Long = CACHE_EXPIRATION_MS,
                           maxNtpResponseTimeMs: Long = MAX_NTP_RESPONSE_TIME_MS): KronosClock {
 
-        val deviceClock = createDeviceClock()
+        val deviceClock = createDeviceClock(context)
         val cache = SharedPreferenceSyncResponseCache(context.getSharedPreferences(SharedPreferenceSyncResponseCache.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE))
 
         return ClockFactory.createKronosClock(deviceClock, cache, syncListener, ntpHosts, requestTimeoutMs, minWaitTimeBetweenSyncMs, cacheExpirationMs, maxNtpResponseTimeMs)

--- a/kronos-android/src/main/java/com/lyft/kronos/internal/AndroidSystemClock.kt
+++ b/kronos-android/src/main/java/com/lyft/kronos/internal/AndroidSystemClock.kt
@@ -1,9 +1,18 @@
 package com.lyft.kronos.internal
 
+import android.content.Context
+import android.os.Build
 import android.os.SystemClock
+import android.provider.Settings
 import com.lyft.kronos.Clock
 
-internal class AndroidSystemClock : Clock {
+internal class AndroidSystemClock(private val context: Context) : Clock {
     override fun getCurrentTimeMs(): Long = System.currentTimeMillis()
     override fun getElapsedTimeMs(): Long = SystemClock.elapsedRealtime()
+    override fun getBootCount(): Int? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Settings.Global.getInt(context.contentResolver, Settings.Global.BOOT_COUNT)
+        } else {
+            null
+        }
 }

--- a/kronos-android/src/main/java/com/lyft/kronos/internal/SharedPreferenceSyncResponseCache.kt
+++ b/kronos-android/src/main/java/com/lyft/kronos/internal/SharedPreferenceSyncResponseCache.kt
@@ -11,6 +11,16 @@ internal class SharedPreferenceSyncResponseCache(private val sharedPreferences: 
     override var elapsedTime: Long
         get() = sharedPreferences.getLong(KEY_ELAPSED_TIME, TIME_UNAVAILABLE)
         set(value) = sharedPreferences.edit().putLong(KEY_ELAPSED_TIME, value).apply()
+    override var bootCount: Int?
+        get() =
+            if (sharedPreferences.contains(KEY_BOOT_COUNT))
+                sharedPreferences.getInt(KEY_BOOT_COUNT, 0)
+            else null
+        set(value) =
+            if (value == null)
+                sharedPreferences.edit().remove(KEY_BOOT_COUNT).apply()
+            else
+                sharedPreferences.edit().putInt(KEY_BOOT_COUNT, value).apply()
     override var currentOffset: Long
         get() = sharedPreferences.getLong(KEY_OFFSET, TIME_UNAVAILABLE)
         set(value) = sharedPreferences.edit().putLong(KEY_OFFSET, value).apply()
@@ -23,6 +33,7 @@ internal class SharedPreferenceSyncResponseCache(private val sharedPreferences: 
         internal const val SHARED_PREFERENCES_NAME = "com.lyft.kronos.shared_preferences"
         internal const val KEY_CURRENT_TIME = "com.lyft.kronos.cached_current_time"
         internal const val KEY_ELAPSED_TIME = "com.lyft.kronos.cached_elapsed_time"
+        internal const val KEY_BOOT_COUNT = "com.lyft.kronos.cached_boot_count"
         internal const val KEY_OFFSET = "com.lyft.kronos.cached_offset"
     }
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/Clock.kt
@@ -10,6 +10,11 @@ interface Clock {
      * @return milliseconds since boot, including time spent in sleep.
      */
     fun getElapsedTimeMs(): Long
+
+    /**
+     * @return boot count. (optional)
+     */
+    fun getBootCount(): Int?
 }
 
 data class KronosTime(

--- a/kronos-java/src/main/java/com/lyft/kronos/SyncResponseCache.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/SyncResponseCache.kt
@@ -2,7 +2,8 @@ package com.lyft.kronos
 
 interface SyncResponseCache {
     var currentTime : Long
-    var elapsedTime : Long
+    var elapsedTime: Long
+    var bootCount: Int?
     var currentOffset: Long
     fun clear()
 }

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/KronosClockImpl.kt
@@ -15,6 +15,8 @@ internal class KronosClockImpl(private val ntpService: SntpService, private val 
 
     override fun getElapsedTimeMs(): Long = fallbackClock.getElapsedTimeMs()
 
+    override fun getBootCount(): Int? = fallbackClock.getBootCount()
+
     override fun getCurrentTime(): KronosTime {
         val currentTime = ntpService.currentTime()
         return currentTime ?: KronosTime(posixTimeMs = fallbackClock.getCurrentTimeMs(), timeSinceLastNtpSyncMs = null)

--- a/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpResponseCache.kt
+++ b/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpResponseCache.kt
@@ -22,9 +22,10 @@ internal class SntpResponseCacheImpl(
         val currentTime = syncResponseCache.currentTime
         val elapsedTime = syncResponseCache.elapsedTime
         val currentOffset = syncResponseCache.currentOffset
+        val bootCount = syncResponseCache.bootCount
         return when (elapsedTime) {
             TIME_UNAVAILABLE -> null
-            else -> SntpClient.Response(currentTime, elapsedTime, currentOffset, deviceClock)
+            else -> SntpClient.Response(currentTime, elapsedTime, bootCount, currentOffset, deviceClock)
         }
     }
 
@@ -32,6 +33,7 @@ internal class SntpResponseCacheImpl(
         synchronized(this) {
             syncResponseCache.currentTime = response.deviceCurrentTimestampMs
             syncResponseCache.elapsedTime = response.deviceElapsedTimestampMs
+            syncResponseCache.bootCount = response.deviceBootCount
             syncResponseCache.currentOffset = response.offsetMs
         }
     }

--- a/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpResponseCacheTest.kt
+++ b/kronos-java/src/test/java/com/lyft/kronos/internal/ntp/SntpResponseCacheTest.kt
@@ -22,6 +22,7 @@ class SntpResponseCacheTest {
     init {
         whenever(deviceClock.getCurrentTimeMs()).thenReturn(CURRENT_TIME_MS)
         whenever(deviceClock.getElapsedTimeMs()).thenReturn(ELAPSED_MS)
+        whenever(deviceClock.getBootCount()).thenReturn(BOOT_COUNT)
         cache = SntpResponseCacheImpl(syncResponseCache, deviceClock)
     }
 
@@ -38,15 +39,18 @@ class SntpResponseCacheTest {
         val currentTime = deviceClock.getCurrentTimeMs()
         val elapsedTime = deviceClock.getElapsedTimeMs()
         val currentOffset = TimeUnit.MINUTES.toMillis(5)
+        val bootCount = deviceClock.getBootCount()
 
         whenever(syncResponseCache.currentTime).thenReturn(currentTime)
         whenever(syncResponseCache.elapsedTime).thenReturn(elapsedTime)
+        whenever(syncResponseCache.bootCount).thenReturn(bootCount)
         whenever(syncResponseCache.currentOffset).thenReturn(currentOffset)
 
         val cachedResponse = cache.get()
         assertThat(cachedResponse).isNotNull()
         assertThat(cachedResponse!!.deviceCurrentTimestampMs).isEqualTo(currentTime)
         assertThat(cachedResponse.deviceElapsedTimestampMs).isEqualTo(elapsedTime)
+        assertThat(cachedResponse.deviceBootCount).isEqualTo(bootCount)
         assertThat(cachedResponse.offsetMs).isEqualTo(currentOffset)
     }
 
@@ -75,11 +79,12 @@ class SntpResponseCacheTest {
     @Throws(Exception::class)
     fun testUpdate() {
         val currentOffset = TimeUnit.HOURS.toMillis(5)
-        val response = SntpClient.Response(CURRENT_TIME_MS, ELAPSED_MS, currentOffset, deviceClock)
+        val response = SntpClient.Response(CURRENT_TIME_MS, ELAPSED_MS, BOOT_COUNT, currentOffset, deviceClock)
         cache.update(response)
 
         verify(syncResponseCache, times(1)).currentTime = CURRENT_TIME_MS
         verify(syncResponseCache, times(1)).elapsedTime = ELAPSED_MS
+        verify(syncResponseCache, times(1)).bootCount = BOOT_COUNT
         verify(syncResponseCache, times(1)).currentOffset = currentOffset
     }
 
@@ -95,5 +100,6 @@ class SntpResponseCacheTest {
 
         private val CURRENT_TIME_MS = 1522964196L
         private val ELAPSED_MS = TimeUnit.HOURS.toMillis(8)
+        private val BOOT_COUNT = 10
     }
 }


### PR DESCRIPTION
to fix #61 
related to https://github.com/lyft/Kronos-Android/issues/61#issuecomment-1035936886

Using the difference between deviceCurrentTime and deviceElapsedTime can trigger false negative on `isFromSameBoot`.
To avoid this false-negative case, this PR uses boot count from [Settings.Global.BOOT_COUNT](https://developer.android.com/reference/android/provider/Settings.Global.html#BOOT_COUNT).

For case when bootCount is not available to the device (e.g. without Android or android sdk below 24) this PR uses bootCount only when it's available. When there is no bootCount, it uses the same algorithm that has been used before this PR.